### PR TITLE
Fixes instability issue in update_with_missing that could result in NaN

### DIFF
--- a/src/update_with_missing.cpp
+++ b/src/update_with_missing.cpp
@@ -99,6 +99,8 @@ int update_with_missing(mat & H, const mat & Wt, const mat & A, const umat & mas
 				WtW.diag() += beta(0) - beta(1);
 			if (beta(1) != 0)
 				WtW += beta(1);
+
+			WtW.diag() += TINY_NUM; // for stability: avoid divided by 0 in scd_ls, scd_kl
 		}
 
 		int iter = 0;


### PR DESCRIPTION
In some edge cases, one or more instances of the diagonal value of the WtW matrix could be zero leading to the propagation of NaNs. This is not a problem in the update function where a stability constant, TINY_NUM is added to the diagonal values--but this was left out in the update_with_missing function. This fix adds this to the update_with_missing function.